### PR TITLE
feat: add parser interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
 export * from './http';
 export * from './node';
+export * from './parsers';
 export * from './server';
+export * from './validations';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/types",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Stoplight <support@stoplight.io>",
   "license": "MIT",
   "main": "./index.d.ts",

--- a/parsers/index.d.ts
+++ b/parsers/index.d.ts
@@ -1,0 +1,23 @@
+import { IValidation } from '../validations';
+
+export type SourceMapParser<T = any> = (value: string) => IParserResult<T>;
+
+export interface IPosition {
+  /** line number (should start at 1) */
+  line: number;
+}
+
+export interface IPathPosition {
+  start: IPosition;
+  end?: IPosition;
+}
+
+export interface IParserResultPointers {
+  [path: string]: IPathPosition;
+}
+
+export interface IParserResult<T = any> {
+  data: T;
+  pointers: IParserResultPointers;
+  validations: IValidation[];
+}

--- a/validations/index.d.ts
+++ b/validations/index.d.ts
@@ -1,0 +1,11 @@
+import { IPathPosition } from '../parsers';
+
+export interface IValidation {
+  ruleId: string;
+
+  /** Starting line of error */
+  line?: number;
+
+  column?: number;
+  location?: IPathPosition;
+}


### PR DESCRIPTION
Note, @chris-miaskowski we might want to organize the HTTP related interfaces into an HTTP folder (similar to how I put the parser and validator stuff into their own folders)?

In case it's helpful, this is one spot these are used: https://github.com/stoplightio/json

I'm adding the YAML source map parser repo tomorrow.

Studio will also use the parser interfaces.