### PR TITLE
fix: remove version from types [SD-438]

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -37,7 +37,6 @@ export interface IHttpOperation extends INode {
   servers: IServer[];
   security: HttpSecurityScheme[];
   deprecated?: boolean;
-  version?: string;
 }
 
 export interface IHttpOperationRequest {

--- a/src/servers.ts
+++ b/src/servers.ts
@@ -6,5 +6,4 @@ export interface IServer {
   name?: string;
   description?: string;
   variables?: Dictionary<INodeVariable, string>;
-  version?: string;
 }


### PR DESCRIPTION
We originally wanted version in data for nodes requiring this version properties to be added. We have since changed directions and no longer need these props.