### PR TITLE
feat: Move schema property from content to request

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@stoplight/scripts": "7.0.0",
     "@types/jest": "^24.0.13",
+    "@types/json-schema": "^7.0.3",
     "@types/node": "^12.0.2",
     "jest": "^24.8.0",
     "lodash": "^4.17.11",

--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -39,13 +39,17 @@ export interface IHttpOperation extends INode {
   deprecated?: boolean;
 }
 
+export type IParametersWithSchema<T> = {
+  values: T[];
+  schema: JSONSchema7;
+};
+
 export interface IHttpOperationRequest {
-  path: IHttpPathParam[];
-  query: IHttpQueryParam[];
-  headers: IHttpHeaderParam[];
-  cookie: IHttpCookieParam[];
+  path: IParametersWithSchema<IHttpPathParam>;
+  query: IParametersWithSchema<IHttpQueryParam>;
+  headers: IParametersWithSchema<IHttpHeaderParam>;
+  cookie: IParametersWithSchema<IHttpCookieParam>;
   body?: IHttpOperationRequestBody;
-  parametersSchema: JSONSchema7;
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject
@@ -122,13 +126,13 @@ export interface IHttpCookieParam extends IHttpParam {
  */
 
 export interface IHttpContent {
-  schema?: ISchema;
   examples: Array<INodeExample | INodeExternalExample>;
   encodings: IHttpEncoding[];
 }
 
 export interface IMediaTypeContent extends IHttpContent {
   mediaType: string;
+  schema?: ISchema;
 }
 
 export interface IHttpEncoding {

--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -1,8 +1,8 @@
+import { JSONSchema7 } from 'json-schema';
 import { Dictionary } from './basic';
 import { INode, INodeExample, INodeExternalExample } from './graph';
 import { ISchema } from './schemas';
 import { IServer } from './servers';
-
 /**
  * HTTP Service
  */
@@ -45,6 +45,7 @@ export interface IHttpOperationRequest {
   headers: IHttpHeaderParam[];
   cookie: IHttpCookieParam[];
   body?: IHttpOperationRequestBody;
+  parametersSchema: JSONSchema7;
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
The following PR will move the schema property from the `content` object that's present in every parameter (header, query, path) to the `request` object.

The reasoning for this is — for different limitations of the schema model of OpenAPI 2 and 3, we can't produce a decent JSON Schema for a single parameter, but we can produce a good one if we consider the whole parameter object

So the plan is, when creating the various parameter objects, collect all the informations about them and create a single schema validating the whole object.

This is a **breaking change**

SO-235