### PR TITLE
Update to TS 3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
   "devDependencies": {
     "@stoplight/scripts": "7.0.0",
     "@types/jest": "^24.0.13",
-    "@types/node": "^12.0.2",
+    "@types/node": "^12.0.3",
     "jest": "^24.8.0",
     "lodash": "^4.17.11",
     "ts-jest": "^24.0.2",
     "tslint": "^5.16.0",
     "tslint-config-stoplight": "^1.3.0",
-    "typescript": "3.4.5"
+    "typescript": "3.5.1"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "tslint --fix",
+      "tslint -c tslint.json --fix",
       "git add"
     ]
   },

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -20,9 +20,6 @@ export type DeepReadonly<T> = T extends Primitive
   : T extends Array<infer U> ? ReadonlyArray<U> : T extends Function ? T : DeepReadonlyObject<T>;
 type DeepReadonlyObject<T> = { readonly [P in keyof T]: DeepReadonly<T[P]> };
 
-/** Omit given key in object type */
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 /** Easy create opaque types ie. types that are subset of their original types (ex: positive numbers, uppercased string) */
 export type Opaque<K, T> = T & { __TYPE__: K };
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,15 +1,16 @@
 // This config is used by `sl-scripts build` and `sl-scripts build.docs`
 {
   "extends": "./tsconfig.json",
-
   // NOTE: must only include one element, otherwise build process into dist folder ends up with incorrect structure
-  "include": ["src"],
-
+  "include": [
+    "src"
+  ],
   // Ignore dev folders like __tests__ and __stories__ when building for distribution
-  "exclude": ["**/__*__/**"],
-
+  "exclude": [
+    "**/__*__/**"
+  ],
   "compilerOptions": {
     "outDir": "dist",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,6 +857,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
   integrity sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==
 
+"@types/node@^12.0.3":
+  version "12.0.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.3.tgz#5d8d24e0033fc6393efadc85cb59c1f638095c9a"
+  integrity sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -8078,10 +8083,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
1. Update to TS 3.5
2. Removes `Omit` (it's now included in TS)
3. Provides CommonJS in case somebody (me) wants to use TSC instead of Rollup
4. Updates types

This is a breaking change