### PR TITLE
refactor: remove content

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -72,7 +72,6 @@ export interface IHttpOperationResponse {
 export interface IHttpParam extends IHttpContent {
   name: string;
   style: HttpParamStyles;
-  content?: IHttpContent;
   description?: string;
   explode?: boolean;
   required?: boolean;

--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -33,7 +33,7 @@ export interface IHttpOperation extends INode {
   method: string;
   path: string;
   request?: IHttpOperationRequest;
-  responses?: IHttpOperationResponse[];
+  responses: IHttpOperationResponse[] & { 0: IHttpOperationResponse };
   servers?: IServer[];
   security?: HttpSecurityScheme[];
   deprecated?: boolean;


### PR DESCRIPTION
Unfortunately another breaking change. Since params extends the content, the `content` property is not required anymore.