### PR TITLE
fix: export node ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './logs';
 export * from './parsers';
 export * from './servers';
 export * from './diagnostics';
+export * from './node';


### PR DESCRIPTION
Didn't realize everything needs to be exported from index 😬 

Otherwise you're forced to do `import { NodeType } from '@stoplight/types/dist/node';`