### PR TITLE
fix: put trace in common verbs

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1,8 +1,8 @@
 import { Dictionary } from './basic';
 import { IHttpOperation } from './http-spec';
 
-export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options';
-export type ExtendedHttpMethod = HttpMethod | 'trace' | 'copy' | 'link' | 'unlink' | 'purge' | 'lock' | 'unlock';
+export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options' | 'trace';
+export type ExtendedHttpMethod = HttpMethod | 'copy' | 'link' | 'unlink' | 'purge' | 'lock' | 'unlock';
 
 export interface IHttpLog<T = any> {
   request: IHttpRequest<T>;


### PR DESCRIPTION
Trace is in OAS3 spec so it's so common that it makes sense to have it in the regular `HttpMethods`