### PR TITLE
feat: callbacks support

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -40,9 +40,9 @@ export interface IHttpOperation extends INode {
   deprecated?: boolean;
 }
 
-export interface IHttpCallbackOperation extends IHttpOperation {
+export type IHttpCallbackOperation = Omit<IHttpOperation, 'servers' | 'security' | 'callbacks'> & {
   callbackName: string;
-}
+};
 
 export interface IHttpOperationRequest {
   path?: IHttpPathParam[];

--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -35,8 +35,13 @@ export interface IHttpOperation extends INode {
   request?: IHttpOperationRequest;
   responses: IHttpOperationResponse[] & { 0: IHttpOperationResponse };
   servers?: IServer[];
+  callbacks?: IHttpCallbackOperation[];
   security?: HttpSecurityScheme[][];
   deprecated?: boolean;
+}
+
+export interface IHttpCallbackOperation extends IHttpOperation {
+  callbackName: string;
 }
 
 export interface IHttpOperationRequest {


### PR DESCRIPTION
Introduces an IHttpOperation extension called IHttpCallbackOperation. The new interface carries additionally the name of callback operation.

The motivation behind extending the interface: callbacks in OASv3 spec are wrapped in an object with callback name as property and operation as value. SL's way of representing such objects is to convert it to an array and add a property inside with the key name (see operations array, examples array, etc.). This change is compatible with that approach.

**Related PR**: https://github.com/stoplightio/prism/pull/716
**Related issue**: https://github.com/stoplightio/prism/issues/331
**The spec**: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#callbackObject
**Callback example**: https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/callback-example.yaml