### PR TITLE
feat: add digest to basic security scheme

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -181,7 +181,7 @@ export interface IBearerSecurityScheme extends ISecurityScheme {
 
 export interface IBasicSecurityScheme extends ISecurityScheme {
   type: 'http';
-  scheme: 'basic';
+  scheme: 'basic' | 'digest';
 }
 
 export interface IOpenIdConnectSecurityScheme extends ISecurityScheme {


### PR DESCRIPTION
It turns out Prism has full support for digest scheme when auth type is basic. I am working on some "type-safe" things into it and I discovered this case was not covered at all. This PR fixes it.