### PR TITLE
Teach Dictionary to accept an enum as a key

### DIFF
--- a/src/basic.ts
+++ b/src/basic.ts
@@ -4,7 +4,7 @@
 export type Primitive = string | number | boolean | undefined | null;
 
 /** Dictionaries related */
-export type Dictionary<T, K extends string | number = string> = { [key in K]: T };
+export type Dictionary<T, K extends string | symbol | number = string> = { [key in K]: T };
 export type DictionaryValues<T> = T extends Dictionary<infer U> ? U : never;
 
 /** Like Partial but recursive */


### PR DESCRIPTION
Beside the straightforward handiness of being able to use enum values as keys, this would be used in https://github.com/stoplightio/spectral/issues/788

/cc @philsturgeon @P0lip 