### PR TITLE
feat: add `NodeType.SpectralBundle`

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -11,6 +11,7 @@ export enum NodeType {
   Unknown = 'unknown',
   TableOfContents = 'table_of_contents',
   SpectralRuleset = 'spectral_ruleset',
+  SpectralBundle = 'spectral_bundle',
 }
 
 /**


### PR DESCRIPTION
In order to create a VirtualNode whose contents are the derived artifact of bundling a SpectralRuleset node, we need to have a unique NodeType value for it. At least as far as I can tell. So here we are!