### PR TITLE
feat: add the unknown param type

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -75,6 +75,7 @@ export interface IHttpOperationRequest<Bundle extends boolean = false> {
   query?: (Bundle extends true ? IHttpQueryParam<true> | Reference : IHttpQueryParam<false>)[];
   headers?: (Bundle extends true ? IHttpHeaderParam<true> | Reference : IHttpHeaderParam<false>)[];
   cookie?: (Bundle extends true ? IHttpCookieParam<true> | Reference : IHttpCookieParam<false>)[];
+  unknown?: Reference[];
   body?: Bundle extends true ? IHttpOperationRequestBody<true> | Reference : IHttpOperationRequestBody<false>;
 }
 


### PR DESCRIPTION
A catch-all bucket for request parameters that we cannot resolve during the transformation to http-spec. Currently we throw these parameters away completely, which is lossy. The main use case is parameters that are a root $ref, which means we cannot infer what type of parameter it is without following the ref, which is not always possible at transformation time.