### PR TITLE
feat(http): adds security declaration type to operation

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -1,7 +1,13 @@
-import { JSONSchema7 } from 'json-schema';
-import { Dictionary } from './basic';
-import { IComponentNode, INode, INodeExample, INodeExternalExample, IShareableNode } from './graph';
-import { IServer } from './servers';
+import { JSONSchema7 } from "json-schema";
+import { Dictionary } from "./basic";
+import {
+  IComponentNode,
+  INode,
+  INodeExample,
+  INodeExternalExample,
+  IShareableNode,
+} from "./graph";
+import { IServer } from "./servers";
 
 /**
  * HTTP Service
@@ -33,7 +39,8 @@ export interface IHttpService extends INode, IShareableNode {
   internal?: boolean;
 }
 
-export interface IBundledHttpService extends Omit<IHttpService, 'securitySchemes'> {
+export interface IBundledHttpService
+  extends Omit<IHttpService, "securitySchemes"> {
   operations: IHttpOperation<true>[];
 
   components: {
@@ -43,8 +50,10 @@ export interface IBundledHttpService extends Omit<IHttpService, 'securitySchemes
     query: (IComponentNode & (IHttpQueryParam<true> | Reference))[];
     header: (IComponentNode & (IHttpHeaderParam<true> | Reference))[];
     cookie: (IComponentNode & (IHttpCookieParam<true> | Reference))[];
-    examples: (IComponentNode & (INodeExample | INodeExternalExample | Reference))[];
-    requestBodies: (IComponentNode & (IHttpOperationRequestBody<true> | Reference))[];
+    examples: (IComponentNode &
+      (INodeExample | INodeExternalExample | Reference))[];
+    requestBodies: (IComponentNode &
+      (IHttpOperationRequestBody<true> | Reference))[];
     securitySchemes: (IComponentNode & (HttpSecurityScheme | Reference))[];
   };
 }
@@ -53,50 +62,77 @@ export interface IBundledHttpService extends Omit<IHttpService, 'securitySchemes
  * HTTP Operation
  */
 
-export interface IHttpOperation<Bundle extends boolean = false> extends INode, IShareableNode {
+export interface IHttpOperation<Bundle extends boolean = false>
+  extends INode,
+    IShareableNode {
   method: string;
   path: string;
-  request?: Bundle extends true ? IHttpOperationRequest<true> | Reference : IHttpOperationRequest<false>;
+  request?: Bundle extends true
+    ? IHttpOperationRequest<true> | Reference
+    : IHttpOperationRequest<false>;
   responses: (Bundle extends true
-    ? IHttpOperationResponse<true> | (Pick<IHttpOperationResponse, 'code'> & Reference)
+    ?
+        | IHttpOperationResponse<true>
+        | (Pick<IHttpOperationResponse, "code"> & Reference)
     : IHttpOperationResponse<false>)[];
   servers?: IServer[];
-  callbacks?: (Bundle extends true ? IHttpCallbackOperation[] | Reference : IHttpCallbackOperation<false>)[];
+  callbacks?: (Bundle extends true
+    ? IHttpCallbackOperation[] | Reference
+    : IHttpCallbackOperation<false>)[];
   security?: HttpSecurityScheme[][];
+  securityDeclarationType?: HttpOperationSecurityDeclarationTypes;
   deprecated?: boolean;
   internal?: boolean;
 }
 
+export enum HttpOperationSecurityDeclarationTypes {
+  None = "none", // For empty `security` array on operation object
+  Declared = "declared", // For non-empty `security` array on operation object
+  InheritedFromService = "inheritedFromService", // Undefined `security` property on operation object
+}
+
 export interface IHttpCallbackOperation<Bundle extends boolean = false>
-  extends Omit<IHttpOperation<Bundle>, 'callbacks'> {
+  extends Omit<IHttpOperation<Bundle>, "callbacks"> {
   callbackName: string;
 }
 
 export interface IHttpOperationRequest<Bundle extends boolean = false> {
-  path?: (Bundle extends true ? IHttpPathParam<true> | Reference : IHttpPathParam<false>)[];
-  query?: (Bundle extends true ? IHttpQueryParam<true> | Reference : IHttpQueryParam<false>)[];
-  headers?: (Bundle extends true ? IHttpHeaderParam<true> | Reference : IHttpHeaderParam<false>)[];
-  cookie?: (Bundle extends true ? IHttpCookieParam<true> | Reference : IHttpCookieParam<false>)[];
+  path?: (Bundle extends true
+    ? IHttpPathParam<true> | Reference
+    : IHttpPathParam<false>)[];
+  query?: (Bundle extends true
+    ? IHttpQueryParam<true> | Reference
+    : IHttpQueryParam<false>)[];
+  headers?: (Bundle extends true
+    ? IHttpHeaderParam<true> | Reference
+    : IHttpHeaderParam<false>)[];
+  cookie?: (Bundle extends true
+    ? IHttpCookieParam<true> | Reference
+    : IHttpCookieParam<false>)[];
   unknown?: Reference[];
-  body?: Bundle extends true ? IHttpOperationRequestBody<true> | Reference : IHttpOperationRequestBody<false>;
+  body?: Bundle extends true
+    ? IHttpOperationRequestBody<true> | Reference
+    : IHttpOperationRequestBody<false>;
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject
-export interface IHttpOperationRequestBody<Bundle extends boolean = false> extends IShareableNode {
+export interface IHttpOperationRequestBody<Bundle extends boolean = false>
+  extends IShareableNode {
   contents?: IMediaTypeContent<Bundle>[];
   required?: boolean;
   description?: string;
   name?: string;
 }
 
-export interface IHttpOperationResponse<Bundle extends boolean = false> extends IShareableNode {
+export interface IHttpOperationResponse<Bundle extends boolean = false>
+  extends IShareableNode {
   // Note: code MAY contain uppercase "X" to indicate wildcard
   // Examples: 200, 2XX, 4XX, XXX ("default" in OAS)
   // When mocking, should select most specific defined code
   code: string;
   contents?: IMediaTypeContent<Bundle>[];
   headers?: (Bundle extends true
-    ? IHttpHeaderParam<true> | (Pick<IHttpHeaderParam, 'name'> & Reference)
+    ? IHttpHeaderParam<true> | (Pick<IHttpHeaderParam, "name"> & Reference)
     : IHttpHeaderParam<false>)[];
   description?: string;
 }
@@ -106,7 +142,9 @@ export interface IHttpOperationResponse<Bundle extends boolean = false> extends 
  */
 
 // Inspired by: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject
-export interface IHttpParam<Bundle extends boolean = false> extends IHttpContent<Bundle>, IShareableNode {
+export interface IHttpParam<Bundle extends boolean = false>
+  extends IHttpContent<Bundle>,
+    IShareableNode {
   name: string;
   style: HttpParamStyles;
   description?: string;
@@ -116,22 +154,27 @@ export interface IHttpParam<Bundle extends boolean = false> extends IHttpContent
 }
 
 export enum HttpParamStyles {
-  Simple = 'simple',
-  Matrix = 'matrix',
-  Label = 'label',
-  Form = 'form',
-  CommaDelimited = 'commaDelimited',
-  SpaceDelimited = 'spaceDelimited',
-  PipeDelimited = 'pipeDelimited',
-  DeepObject = 'deepObject',
+  Simple = "simple",
+  Matrix = "matrix",
+  Label = "label",
+  Form = "form",
+  CommaDelimited = "commaDelimited",
+  SpaceDelimited = "spaceDelimited",
+  PipeDelimited = "pipeDelimited",
+  DeepObject = "deepObject",
 }
 
-export interface IHttpPathParam<Bundle extends boolean = false> extends IHttpParam<Bundle> {
+export interface IHttpPathParam<Bundle extends boolean = false>
+  extends IHttpParam<Bundle> {
   // should default to simple
-  style: HttpParamStyles.Label | HttpParamStyles.Matrix | HttpParamStyles.Simple;
+  style:
+    | HttpParamStyles.Label
+    | HttpParamStyles.Matrix
+    | HttpParamStyles.Simple;
 }
 
-export interface IHttpQueryParam<Bundle extends boolean = false> extends IHttpParam<Bundle> {
+export interface IHttpQueryParam<Bundle extends boolean = false>
+  extends IHttpParam<Bundle> {
   // should default to form
   style:
     | HttpParamStyles.Form
@@ -144,12 +187,14 @@ export interface IHttpQueryParam<Bundle extends boolean = false> extends IHttpPa
   allowReserved?: boolean;
 }
 
-export interface IHttpHeaderParam<Bundle extends boolean = false> extends IHttpParam<Bundle> {
+export interface IHttpHeaderParam<Bundle extends boolean = false>
+  extends IHttpParam<Bundle> {
   // should default to simple
   style: HttpParamStyles.Simple;
 }
 
-export interface IHttpCookieParam<Bundle extends boolean = false> extends IHttpParam<Bundle> {
+export interface IHttpCookieParam<Bundle extends boolean = false>
+  extends IHttpParam<Bundle> {
   // should default to form
   style: HttpParamStyles.Form;
 }
@@ -158,15 +203,20 @@ export interface IHttpCookieParam<Bundle extends boolean = false> extends IHttpP
  * HTTP Content
  */
 
-export interface IHttpContent<Bundle extends boolean = false> extends IShareableNode {
+export interface IHttpContent<Bundle extends boolean = false>
+  extends IShareableNode {
   schema?: JSONSchema7;
   examples?: (Bundle extends true
-    ? INodeExample | INodeExternalExample | (Pick<INodeExample, 'key'> & Reference)
+    ?
+        | INodeExample
+        | INodeExternalExample
+        | (Pick<INodeExample, "key"> & Reference)
     : INodeExample | INodeExternalExample)[];
   encodings?: IHttpEncoding<Bundle>[];
 }
 
-export interface IMediaTypeContent<Bundle extends boolean = false> extends IHttpContent<Bundle> {
+export interface IMediaTypeContent<Bundle extends boolean = false>
+  extends IHttpContent<Bundle> {
   mediaType: string;
 }
 
@@ -181,7 +231,9 @@ export interface IHttpEncoding<Bundle extends boolean = false> {
     | HttpParamStyles.PipeDelimited
     | HttpParamStyles.DeepObject;
 
-  headers?: (Bundle extends true ? IHttpHeaderParam<true> | Reference : IHttpHeaderParam<false>)[];
+  headers?: (Bundle extends true
+    ? IHttpHeaderParam<true> | Reference
+    : IHttpHeaderParam<false>)[];
   mediaType?: string;
   explode?: boolean;
   allowReserved?: boolean;
@@ -206,34 +258,34 @@ interface ISecurityScheme extends IShareableNode {
 }
 
 export interface IApiKeySecurityScheme extends ISecurityScheme {
-  type: 'apiKey';
+  type: "apiKey";
   name: string;
-  in: 'query' | 'header' | 'cookie';
+  in: "query" | "header" | "cookie";
 }
 
 export interface IBearerSecurityScheme extends ISecurityScheme {
-  type: 'http';
-  scheme: 'bearer';
+  type: "http";
+  scheme: "bearer";
   bearerFormat?: string;
 }
 
 export interface IBasicSecurityScheme extends ISecurityScheme {
-  type: 'http';
-  scheme: 'basic' | 'digest';
+  type: "http";
+  scheme: "basic" | "digest";
 }
 
 export interface IOpenIdConnectSecurityScheme extends ISecurityScheme {
-  type: 'openIdConnect';
+  type: "openIdConnect";
   openIdConnectUrl: string;
 }
 
 export interface IOauth2SecurityScheme extends ISecurityScheme {
-  type: 'oauth2';
+  type: "oauth2";
   flows: IOauthFlowObjects;
 }
 
 export interface IMutualTLSSecurityScheme extends ISecurityScheme {
-  type: 'mutualTLS';
+  type: "mutualTLS";
 }
 
 export interface IOauthFlowObjects {


### PR DESCRIPTION
`@stoplight/http-spec` is going to need to track how the security was defined on an operation.