### PR TITLE
feat(http): adds security declaration type to operation

### DIFF
--- a/src/http-spec.ts
+++ b/src/http-spec.ts
@@ -63,8 +63,15 @@ export interface IHttpOperation<Bundle extends boolean = false> extends INode, I
   servers?: IServer[];
   callbacks?: (Bundle extends true ? IHttpCallbackOperation[] | Reference : IHttpCallbackOperation<false>)[];
   security?: HttpSecurityScheme[][];
+  securityDeclarationType?: HttpOperationSecurityDeclarationTypes;
   deprecated?: boolean;
   internal?: boolean;
+}
+
+export enum HttpOperationSecurityDeclarationTypes {
+  None = 'none', // For empty `security` array on operation object
+  Declared = 'declared', // For non-empty `security` array on operation object
+  InheritedFromService = 'inheritedFromService', // Undefined `security` property on operation object
 }
 
 export interface IHttpCallbackOperation<Bundle extends boolean = false>


### PR DESCRIPTION
`@stoplight/http-spec` is going to need to track how the security was defined on an operation.