### PR TITLE
fix: missing webhook node type

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -7,6 +7,7 @@ export enum NodeType {
   HttpServer = 'http_server',
   HttpOperation = 'http_operation',
   HttpCallback = 'http_callback',
+  HttpWebhook = 'http_webhook',
   Model = 'model',
   Generic = 'generic',
   Unknown = 'unknown',


### PR DESCRIPTION
## Description
Adds missing `NodeType.HttpWebhook` enum value

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
